### PR TITLE
fix: the recent versions of libcamera throws an error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt update && apt install -y --no-install-recommends \
 WORKDIR /app
 
 # Install libcamera from source
-RUN git clone https://github.com/raspberrypi/libcamera.git
+RUN git clone https://github.com/raspberrypi/libcamera.git && cd libcamera && git checkout 6ddd79b && cd ..
 RUN meson setup libcamera/build libcamera/
 RUN ninja -C libcamera/build/ install
 


### PR DESCRIPTION
the recent versions of libcamera is not compatible with the Docker ros base image, requiring a meson dependency version that is not available. The solution was to do a checkout to the a libcamera commit, the last compatible version with the current Docker setup.

Issue Evidence:
<img width="1412" alt="image" src="https://github.com/user-attachments/assets/6367f1ec-2fd0-4bd6-96ef-1b5ca876f1df" />

Solution Evidence:
<img width="1430" alt="image" src="https://github.com/user-attachments/assets/da7987c9-5480-44b8-8056-3027c9bb4eed" />

